### PR TITLE
Fix Snyk dependency vulnerabilities (bump vulnerable NuGet packages)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -17,9 +17,18 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql" Version="7.0.4" />
+    <PackageReference Include="Npgsql" Version="7.0.7" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="7.0.4" />
+  </ItemGroup>
+
+  <!-- Pin transitive dependencies to versions that resolve Snyk-reported security vulnerabilities -->
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.6" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Application.Tests/Application.Tests.csproj
+++ b/tests/Application.Tests/Application.Tests.csproj
@@ -23,6 +23,12 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Pin transitive dependencies to versions that resolve Snyk-reported security vulnerabilities -->
+  <ItemGroup>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Application\Application.csproj" />
   </ItemGroup>

--- a/tests/WebApi.Tests/WebApi.Tests.csproj
+++ b/tests/WebApi.Tests/WebApi.Tests.csproj
@@ -23,6 +23,12 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Pin transitive dependencies to versions that resolve Snyk-reported security vulnerabilities -->
+  <ItemGroup>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Application\Application.csproj" />
     <ProjectReference Include="..\..\src\WebApi\WebApi.csproj" />


### PR DESCRIPTION
## Summary

Resolves the SCA vulnerabilities reported by Snyk by upgrading the affected NuGet packages to fixed versions. Only one package (`Npgsql`) was a direct reference; the rest were transitive, so they are pinned via explicit `PackageReference` entries to the fixed versions. Target framework stays on **net7.0** — no app/runtime code changes, build and all 20 tests pass, and re-scans report **no vulnerable paths**.

### Version bumps

`src/Infrastructure/Infrastructure.csproj` (direct + transitive pins):

| Package | Before | After | Advisory |
|---|---|---|---|
| `Npgsql` (direct) | 7.0.4 | **7.0.7** | SQL Injection (GHSA-x9vc-6hfv-hg8c) |
| `Azure.Identity` | 1.6.0 | **1.11.4** | RCE (GHSA-5mfx-4wcx-rv27) + 2 moderate |
| `Microsoft.Data.SqlClient` | 5.0.2 | **5.1.6** | Unprotected credential storage (GHSA-98g6-xh36-x2p7) |
| `System.Drawing.Common` | 5.0.0 | **6.0.0** | RCE (GHSA-rxg9-xrhp-64gj) |
| `System.Text.Json` | 7.0.0 | **8.0.5** | DoS (GHSA-hh2w-p6rv-4g7w) |
| `System.Formats.Asn1` | 5.0.0 | **8.0.1** | DoS (GHSA-447r-wph3-92pm) |

`tests/Application.Tests` and `tests/WebApi.Tests` (transitive pins from the test SDK):

| Package | Before | After | Advisory |
|---|---|---|---|
| `System.Net.Http` | 4.3.0 | **4.3.4** | DoS / cert validation / info exposure (GHSA-7jgj-8wvc-jh57) |
| `System.Text.RegularExpressions` | 4.3.0 | **4.3.1** | ReDoS (GHSA-cmhx-cq75-c4mj) |

### CI fix (`.github/workflows/dotnet.yml`)

The workflow set up **`dotnet-version: 6.0.x`** for a `net7.0` project. Since GitHub's `ubuntu-latest` image dropped the (EOL) .NET 7 runtime, the `net7.0` testhost had no matching runtime and `dotnet test` failed with *"You must install or update .NET to run this application"* — `main` is already red for this reason. Changed it to **`7.0.x`** so the correct SDK/runtime is installed. This is unrelated to the package bumps (tests pass locally on a machine with only the 7.0 runtime).

### Notes / deviations from the requested versions

- **`System.Text.Json` → 8.0.5** and **`System.Formats.Asn1` → 8.0.1** (instead of 7.x): the relevant advisories have **no fixed release on the 7.x line**. These ship `net6.0`/`netstandard2.0` assets that run on the .NET 7 runtime (verified: tests pass with only `Microsoft.NETCore.App 7.0.20` installed); the framework is unchanged at `net7.0`. The explicit `PackageReference` makes the 8.x assembly take precedence over the in-box shared-framework copy via `*.deps.json`.
- **`System.Drawing.Common` → 6.0.0** (instead of 5.0.3): the upgraded `Microsoft.Data.SqlClient 5.1.6` transitively requires `System.Drawing.Common >= 6.0.0`, so pinning 5.0.3 caused a package-downgrade error (NU1605). 6.0.0 is past the advisory's fixed version (5.0.3), so it remains non-vulnerable.
- `Azure.Identity`, `Microsoft.IdentityModel.*`, and `System.IdentityModel.Tokens.Jwt` moderate findings are also cleared as a side effect of the `Microsoft.Data.SqlClient` / `Azure.Identity` bumps.

### Verification

- `dotnet build` — 0 errors (only pre-existing nullable warnings).
- `dotnet test` — 20/20 pass (6 Application + 14 WebApi).
- `dotnet list package --vulnerable --include-transitive` — no vulnerable packages in any project.
- `npx snyk test --all-projects` — "Tested 6 projects, no vulnerable paths were found."

Link to Devin session: https://app.devin.ai/sessions/044ea2561f2a4bd8b08299e505f73156
Requested by: @shayanshafii
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/webapi-sample-dotnet-7/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->